### PR TITLE
fix(top-nav): fix top-nav causing layout shift in mobile devices

### DIFF
--- a/apps/portfolio/app/components/TopNavigation/TopNavigation.tsx
+++ b/apps/portfolio/app/components/TopNavigation/TopNavigation.tsx
@@ -32,7 +32,15 @@ const TopNavigation = () => {
   const [isOpen, setIsOpen] = useState(false);
   const { resourceValue: currentSong } = store["CURRENT_SONG"]();
   return (
-    <Container flexGrow="0" p="2" position="sticky">
+    <Container
+      flexGrow="0"
+      p="2"
+      position="fixed"
+      style={{
+        width: "100%",
+        zIndex: 1,
+      }}
+    >
       <Card className="top-navigation">
         <Flex direction="row" position="relative" justify="between">
           <Box width="50%">


### PR DESCRIPTION
- Add `position:fixed` with `z-index:1` and `width:100%`

![image](https://github.com/user-attachments/assets/0a4c8f48-4b93-43d9-87d9-b061609aa856)
![image](https://github.com/user-attachments/assets/677bc995-6dcc-4794-bceb-ebd7cd2e81ea)
